### PR TITLE
make `bool checkPort`public

### DIFF
--- a/h6x_packet_handler/include/h6x_packet_handler/rx_ascii_packet.hpp
+++ b/h6x_packet_handler/include/h6x_packet_handler/rx_ascii_packet.hpp
@@ -32,6 +32,7 @@ public:
 
 protected:
   std::array<uint8_t, ASCII_DATA_SIZE / 2 + ASCII_DATA_SIZE % 2> bin_data;
+  std::array<uint8_t, ASCII_ETX_SIZE> crc_data;
   const std::array<char, ASCII_STX_SIZE> STX_ID;
 
 public:
@@ -40,6 +41,7 @@ public:
   : STX_ID(id)
   {
     this->bin_data.fill(0);
+    this->crc_data.fill(0);
   }
 
   virtual bool set(const std::string & buf) noexcept {return this->setBase(buf);}
@@ -82,6 +84,9 @@ protected:
   {
     HexHandler::hex2bin(
       &buf[ASCII_STX_SIZE], this->ASCII_DATA_SIZE, this->bin_data.data(), this->bin_data.size());
+    std::copy(
+      buf.begin() + ASCII_BUF_SIZE - ASCII_ETX_SIZE, buf.begin() + ASCII_BUF_SIZE,
+      this->crc_data.begin());
     return true;
   }
 

--- a/h6x_serial_interface/include/h6x_serial_interface/port_handler.hpp
+++ b/h6x_serial_interface/include/h6x_serial_interface/port_handler.hpp
@@ -31,6 +31,7 @@ private:
 public:
   explicit PortHandler(const std::string &);
   ~PortHandler();
+  bool checkPort(void) const noexcept;
   bool configure(const int = 115200, const int = 10);
   bool open(void);
   bool close(void);
@@ -42,7 +43,6 @@ public:
   ssize_t write(const char * const, const size_t) override;
 
 private:
-  bool checkPort(void) const noexcept;
   static const rclcpp::Logger getLogger(void) noexcept;
 };
 }  // namespace h6x_serial_interface


### PR DESCRIPTION
- Make `bool checkPort` public to detect serial interface connection missing.
- Add `crc_data` (type : `std::array<uint8_t, ASCII_ETX_SIZE>`) for failure detection in checking updates.